### PR TITLE
Update meanFileSeries.py

### DIFF
--- a/TIMEleSS/diffraction/meanFileSeries.py
+++ b/TIMEleSS/diffraction/meanFileSeries.py
@@ -77,7 +77,7 @@ def meanFileSeries(stem,first,last,digits,ext,new,tif):
 		# Open the EDF image file
 		imedf = fabio.open(ifile)
 		# get data and use it as a starting point
-		data += numpy.copy(imedf.data)
+		data += numpy.copy(imedf.data).astype('int64')
 	# calculating mean
 	data = data / (last-first+1)
 	# Preparing a header


### PR DESCRIPTION
Internet solution for the error >>TypeError: Cannot cast ufunc add output from dtype('float64') to dtype('int64') with casting rule 'same_kind'<< 
Clarifies the datatype (float64) which was not necessary in older python versions. 