### PR TITLE
Update multigrainOutputParser.py

### DIFF
--- a/TIMEleSS/general/multigrainOutputParser.py
+++ b/TIMEleSS/general/multigrainOutputParser.py
@@ -230,6 +230,7 @@ q0 qx qy qz
 	output.write(text)
 	output.write("\n")
 	i = 0
+	totalgve = 0
 	for grain in grains:
 		i += 1
 		text = (grain.getGrainSpotterTxt())[:] # we make a copy of the array, this is important
@@ -239,6 +240,11 @@ q0 qx qy qz
 		for line in text:
 			output.write(line)
 			output.write("\n")
+		totalgve += grain.getNPeaks()
+	textsummary = """In total %d gvectors of which %d (%d%%) were assigned:
+%d (%d%%) was not assigned, something once, something more than once.""" % (len(grains), totalgve, totalgve/len(grains)*100, len(grains)-totalgve, 100-totalgve/len(grains)*100) #FIXME The words "something" have to be changed. The term "grains" is still wrong (must be G-vectors instead).
+	output.write(textsummary)
+	output.write("\n")
 	output.close()
 
 


### PR DESCRIPTION
I found the problem in the multigrainOutputParser. When parsing the GrainSpotter log-file the summary lines at the end were deleted to get the pure grain information. But when saving the information into a new log-file the summary lines were not added again. So when repeating the parsing and saving several times, more and more rows at the end of the file were deleted until the script threw an error.

However, I haven't found the place where to get the info about the g-vectors (how many in total, how many assigned, how many assigned twice etc.) For now, this is not important because the changes I made are already enough to make the script working but it has still to be implemented at some point.